### PR TITLE
Switch novelty analysis to GPU-ready transformer summarizer

### DIFF
--- a/app/arxiv_fetcher.py
+++ b/app/arxiv_fetcher.py
@@ -1,119 +1,163 @@
-import requests
+import asyncio
+import logging
 import xml.etree.ElementTree as ET
 from datetime import datetime
-import logging
-import asyncio
-import ollama 
+from threading import Lock
+from typing import Iterable, List
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+import requests
+import torch
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 
-ARXIV_API_URL = 'http://export.arxiv.org/api/query?'
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+ARXIV_API_URL = "http://export.arxiv.org/api/query?"
+MODEL_NAME = "sshleifer/distilbart-cnn-12-6"
+_DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+_MODEL_LOCK = Lock()
+_TOKENIZER = None
+_MODEL = None
+
+
+def _load_summarizer():
+    """LLMのトークナイザーとモデルをGPU優先でロードする。"""
+    global _TOKENIZER, _MODEL
+    with _MODEL_LOCK:
+        if _TOKENIZER is None or _MODEL is None:
+            logging.info("LLMモデルをロードしています (device=%s)...", _DEVICE)
+            _TOKENIZER = AutoTokenizer.from_pretrained(MODEL_NAME)
+            dtype = torch.float16 if _DEVICE.type == "cuda" else torch.float32
+            _MODEL = AutoModelForSeq2SeqLM.from_pretrained(MODEL_NAME, torch_dtype=dtype)
+            _MODEL.to(_DEVICE)
+            _MODEL.eval()
+    return _TOKENIZER, _MODEL
+
+
+def _summarize_abstract(abstract: str) -> str:
+    """同期的に要旨を要約し、新規性の説明テキストを生成する。"""
+    if not abstract.strip():
+        return "要約対象の要旨が空でした。"
+
+    tokenizer, model = _load_summarizer()
+    inputs = tokenizer(
+        abstract,
+        return_tensors="pt",
+        truncation=True,
+        max_length=1024,
+    ).to(_DEVICE)
+
+    with torch.inference_mode():
+        summary_ids = model.generate(
+            **inputs,
+            max_new_tokens=160,
+            num_beams=4,
+            early_stopping=True,
+        )
+
+    summary = tokenizer.decode(summary_ids[0], skip_special_tokens=True)
+    return summary.strip()
+
 
 async def analyze_novelty_with_llm(abstract: str) -> str:
-    """
-    ローカルで実行されているLLM (Ollama) を使って論文の要旨から新規性を分析・要約する関数
-
-    Args:
-        abstract (str): 論文の要旨
-
-    Returns:
-        str: LLMによって生成された新規性の要約。エラー時はメッセージを返す。
-    """
-    prompt = f"""
-    You are an excellent research assistant.
-    Please read the abstract of the paper below and identify the "novelty" and "contribution" of this research.
-    Then, provide a concise summary of them in approximately 70-100 words.
-
-    ---
-    Abstract: 
-    {abstract}
-    ---
-
-    Summary of Novelty:
-    """
+    """GPU (利用可能な場合) で動作するLLMを使って要旨を要約する。"""
     try:
-        # Ollamaの非同期クライアントを使用してLLMにリクエストを送信
-        response = await ollama.AsyncClient().chat(
-            model='deepseek-r1:1.5b',  # 使用するモデルを指定 (例: 'llama3', 'gemma')
-            messages=[{'role': 'user', 'content': prompt}]
-        )
-        return response['message']['content'].strip()
-    except Exception as e:
-        logging.error(f"Ollamaでの分析中にエラーが発生しました: {e}")
-
-        return "Ollamaでの分析中にエラーが発生しました。Ollamaアプリが起動しているか、指定したモデル (`llama3`など) がダウンロードされているか確認してください。"
+        return await asyncio.to_thread(_summarize_abstract, abstract)
+    except Exception as exc:  # pragma: no cover - 例外時のフォールバック
+        logging.error("LLMによる要約中にエラーが発生しました: %s", exc)
+        return "ローカルLLMでの要約に失敗しました。モデルのダウンロード状況やGPUメモリを確認してください。"
 
 
-async def fetch_arxiv_papers(search_query: str, max_results_per_query: int = 10):
+async def fetch_arxiv_papers(search_queries: Iterable[str], max_results_per_query: int = 10) -> List[dict]:
     """
-    複数のキーワードで論文を検索し、新規性を分析して結果を返す非同期関数
+    複数のクエリで論文を検索し、GPU対応LLMで新規性を分析する。
 
     Args:
-        search_query (str): 検索したいキーワードのリスト
-        max_results_per_query (int): 1クエリあたりの最大取得論文数
+        search_queries (Iterable[str]): 検索クエリまたはクエリのリスト。
+        max_results_per_query (int): 1クエリあたりの最大取得論文数。
 
     Returns:
         list: 論文情報の辞書を含むリスト。エラー時は空リストを返す。
     """
+
+    if isinstance(search_queries, str):
+        queries = [search_queries]
+    else:
+        queries = [q for q in search_queries if q]
+
     unique_papers = {}
 
-    query = search_query 
-    logging.info(f"'{query}'に関する論文を検索中...")
-    params = {
-        'search_query': query,
-        'sortBy': 'submittedDate',
-        'sortOrder': 'descending',
-        'max_results': str(max_results_per_query)
-    }
-    try:
-        response = requests.get(ARXIV_API_URL, params=params)
-        response.raise_for_status()
-        
-        root = ET.fromstring(response.content)
-        namespaces = {'arxiv': 'http://www.w3.org/2005/Atom'}
+    for query in queries:
+        logging.info("'%s' に関する論文を検索中...", query)
+        params = {
+            "search_query": query,
+            "sortBy": "submittedDate",
+            "sortOrder": "descending",
+            "max_results": str(max_results_per_query),
+        }
+        try:
+            response = requests.get(ARXIV_API_URL, params=params, timeout=10)
+            response.raise_for_status()
 
-        for entry in root.findall('arxiv:entry', namespaces):
-            paper_id = entry.find('arxiv:id', namespaces).text
-            if paper_id not in unique_papers: # 重複をチェック
-                title = entry.find('arxiv:title', namespaces).text.strip()
-                summary = entry.find('arxiv:summary', namespaces).text.strip().replace('\n', ' ')
-                
+            root = ET.fromstring(response.content)
+            namespaces = {
+                "atom": "http://www.w3.org/2005/Atom",
+                "arxiv": "http://arxiv.org/schemas/atom",
+            }
+
+            for entry in root.findall("atom:entry", namespaces):
+                paper_id = entry.findtext("atom:id", default="", namespaces=namespaces)
+                if not paper_id or paper_id in unique_papers:
+                    continue
+
+                title = entry.findtext("atom:title", default="", namespaces=namespaces).strip()
+                summary = (
+                    entry.findtext("atom:summary", default="", namespaces=namespaces)
+                    .strip()
+                    .replace("\n", " ")
+                )
+                published_raw = entry.findtext("atom:published", default="", namespaces=namespaces)
+                try:
+                    published_date = datetime.strptime(published_raw, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%d")
+                except ValueError:
+                    published_date = published_raw
+
+                authors = [
+                    author.findtext("atom:name", default="", namespaces=namespaces)
+                    for author in entry.findall("atom:author", namespaces)
+                ]
+                authors = [author for author in authors if author]
+
                 unique_papers[paper_id] = {
-                    'title': title,
-                    'authors': [author.find('arxiv:name', namespaces).text for author in entry.findall('arxiv:author', namespaces)],
-                    'summary': summary,
-                    'published_date': datetime.strptime(entry.find('arxiv:published', namespaces).text, "%Y-%m-%dT%H:%M:%SZ").strftime('%Y-%m-%d'),
-                    'url': paper_id,
-                    'novelty': '' # 後で分析結果を入れるための空欄
+                    "title": title,
+                    "authors": authors,
+                    "summary": summary,
+                    "published_date": published_date,
+                    "url": paper_id,
+                    "novelty": "",
                 }
-    except requests.exceptions.RequestException as e:
-        logging.error(f"APIリクエストエラー (クエリ: {query}): {e}")
-    except ET.ParseError as e:
-        logging.error(f"XML解析エラー (クエリ: {query}): {e}")
+        except requests.exceptions.RequestException as exc:
+            logging.error("APIリクエストエラー (クエリ: %s): %s", query, exc)
+        except ET.ParseError as exc:
+            logging.error("XML解析エラー (クエリ: %s): %s", query, exc)
 
     if not unique_papers:
         return []
 
-    # LLMによる新規性分析を並行して実行
-    logging.info(f"{len(unique_papers)}件のユニークな論文の新規性を分析します...")
-    tasks = [
-        analyze_novelty_with_llm(paper['summary']) 
-        for paper in unique_papers.values()
-    ]
+    logging.info("%d件のユニークな論文の新規性を分析します...", len(unique_papers))
+    tasks = [analyze_novelty_with_llm(paper["summary"]) for paper in unique_papers.values()]
     novelty_results = await asyncio.gather(*tasks)
 
-    # 分析結果を元の辞書に格納
     for paper, novelty_text in zip(unique_papers.values(), novelty_results):
-        paper['novelty'] = novelty_text
+        paper["novelty"] = novelty_text
 
-    # 投稿日でソートしてリストとして返す
-    sorted_papers = sorted(list(unique_papers.values()), key=lambda p: p['published_date'], reverse=True)
+    sorted_papers = sorted(unique_papers.values(), key=lambda p: p["published_date"], reverse=True)
     return sorted_papers
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     test_query = "happy"
-    results = asyncio.run(fetch_arxiv_papers(search_query=test_query, max_results_per_query=3))
-    
+    results = asyncio.run(fetch_arxiv_papers(search_queries=test_query, max_results_per_query=3))
+
     if results:
         for i, paper in enumerate(results):
             print("-" * 50)

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
-import streamlit as st
 import asyncio
-from arxiv_fetcher import fetch_arxiv_papers # こちらのファイルに変更はありません
+
+import streamlit as st
+
+from arxiv_fetcher import fetch_arxiv_papers
 
 # --- ページ設定 ---
 st.set_page_config(
@@ -15,7 +17,10 @@ st.markdown("""
 このアプリは、arXiv.orgに投稿された論文を検索し、**あなたのPCで動作するLLMが各論文の新規性を要約**します。
 複数のキーワードを**カンマ（,）**で区切って入力することで、それら全てを含む論文をAND検索できます。
 """)
-st.warning("**注意:** このアプリを使用するには、事前にOllamaをインストールし、バックグラウンドで起動しておく必要があります。")
+st.warning(
+    "**注意:** 初回実行時にHugging Faceの要約モデルをダウンロードします。"
+    " GPUが利用可能な場合は自動的に使用されます。"
+)
 
 
 # --- サイドバー ---
@@ -45,10 +50,12 @@ if st.sidebar.button("分析を実行"):
         st.sidebar.success("生成されたクエリ:")
         st.sidebar.code(final_query, language='text')
 
-        with st.spinner("論文データを取得し、ローカルLLMで新規性を分析しています... PCの性能によっては時間がかかります。"):
+        with st.spinner(
+            "論文データを取得し、ローカルLLM (GPU対応) で新規性を分析しています。"
+            " 初回はモデルの読み込みに時間がかかる場合があります。"
+        ):
             try:
-                # 生成した単一のクエリをリストに入れてfetcherに渡す
-                papers = asyncio.run(fetch_arxiv_papers([final_query], max_results))
+                papers = asyncio.run(fetch_arxiv_papers(final_query, max_results))
             except Exception as e:
                 st.error(f"処理中にエラーが発生しました: {e}")
                 papers = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+requests
+torch
+transformers


### PR DESCRIPTION
## Summary
- fix the Atom namespace usage so arXiv feeds are parsed correctly and allow multiple queries per request
- replace the Ollama chat call with a GPU-aware Hugging Face summarizer and run blocking calls via asyncio.to_thread
- refresh the Streamlit messaging and dependency list to reflect the GPU-enabled local model

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36f205bc4832180181eef1f322f2a