### PR TITLE
Switch novelty analysis to GPU summarizer

### DIFF
--- a/app/arxiv_fetcher.py
+++ b/app/arxiv_fetcher.py
@@ -1,123 +1,208 @@
-import requests
+"""Utility functions for querying arXiv and analysing novelty on GPU."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
 import xml.etree.ElementTree as ET
 from datetime import datetime
-import logging
-import asyncio
-import ollama 
+from typing import Any, Dict, List, Optional
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+import requests
 
-ARXIV_API_URL = 'http://export.arxiv.org/api/query?'
 
-async def analyze_novelty_with_llm(abstract: str) -> str:
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+ARXIV_API_URL = "http://export.arxiv.org/api/query?"
+ATOM_NAMESPACE = "http://www.w3.org/2005/Atom"
+ARXIV_NAMESPACE = "http://arxiv.org/schemas/atom"
+NAMESPACES = {"atom": ATOM_NAMESPACE, "arxiv": ARXIV_NAMESPACE}
+
+
+class NoveltyAnalyzer:
+    """Summarise an abstract with a Transformer model running on GPU when available.
+
+    The class lazily loads a Hugging Face summarisation pipeline.  Loading the
+    model is expensive, so the instance keeps the pipeline cached and protects
+    the initialisation with a thread lock.  Inference is executed in a worker
+    thread via :func:`asyncio.to_thread` so that multiple abstracts can be
+    analysed concurrently from an async context without blocking the event loop.
     """
-    ローカルで実行されているLLM (Ollama) を使って論文の要旨から新規性を分析・要約する関数
+
+    def __init__(
+        self,
+        model_name: str = "sshleifer/distilbart-cnn-12-6",
+        *,
+        max_summary_tokens: int = 120,
+    ) -> None:
+        self.model_name = model_name
+        self.max_summary_tokens = max_summary_tokens
+        self._pipeline = None
+        self._pipeline_lock = threading.Lock()
+
+    def _ensure_pipeline(self):
+        """Load the Hugging Face pipeline on the GPU the first time it is needed."""
+        if self._pipeline is None:
+            with self._pipeline_lock:
+                if self._pipeline is None:
+                    from transformers import pipeline  # Lazy import to keep start-up light.
+                    import torch
+
+                    device = 0 if torch.cuda.is_available() else -1
+                    logging.info(
+                        "Loading summarisation model '%s' on %s.",
+                        self.model_name,
+                        "GPU" if device >= 0 else "CPU",
+                    )
+                    self._pipeline = pipeline(
+                        task="summarization",
+                        model=self.model_name,
+                        tokenizer=self.model_name,
+                        device=device,
+                    )
+        return self._pipeline
+
+    def _summarise_sync(self, abstract: str) -> str:
+        if not abstract.strip():
+            return "要旨が空のため、要約を生成できませんでした。"
+
+        summariser = self._ensure_pipeline()
+        result = summariser(
+            abstract,
+            max_length=self.max_summary_tokens,
+            min_length=max(20, self.max_summary_tokens // 2),
+            truncation=True,
+        )[0]
+        return result["summary_text"].strip()
+
+    async def analyse(self, abstract: str) -> str:
+        """Analyse the abstract asynchronously.
+
+        The heavy lifting happens in a background thread so that coroutine callers
+        can continue to await concurrently.
+        """
+        try:
+            return await asyncio.to_thread(self._summarise_sync, abstract)
+        except Exception as exc:  # pragma: no cover - defensive guard against runtime failures
+            logging.error("GPU要約モデルの推論に失敗しました: %s", exc)
+            return "GPU要約モデルでの分析中にエラーが発生しました。モデルと依存ライブラリを確認してください。"
+
+
+async def fetch_arxiv_papers(
+    search_query: str,
+    max_results_per_query: int = 10,
+    *,
+    novelty_analyzer: Optional[NoveltyAnalyzer] = None,
+) -> List[Dict[str, Any]]:
+    """Query arXiv for a keyword string and analyse the novelty of each paper.
 
     Args:
-        abstract (str): 論文の要旨
+        search_query: arXiv API query string (e.g. ``all:"diffusion" AND cat:cs.CV``).
+        max_results_per_query: Maximum number of results to fetch from the API.
+        novelty_analyzer: Optional ``NoveltyAnalyzer``.  Passing one makes unit
+            testing easier and allows reusing a pre-loaded model.
 
     Returns:
-        str: LLMによって生成された新規性の要約。エラー時はメッセージを返す。
+        A list of dictionaries describing papers sorted by published date.
     """
-    prompt = f"""
-    You are an excellent research assistant.
-    Please read the abstract of the paper below and identify the "novelty" and "contribution" of this research.
-    Then, provide a concise summary of them in approximately 70-100 words.
 
-    ---
-    Abstract: 
-    {abstract}
-    ---
+    if not isinstance(search_query, str) or not search_query.strip():
+        raise ValueError("search_query には空でない文字列を指定してください。")
 
-    Summary of Novelty:
-    """
-    try:
-        # Ollamaの非同期クライアントを使用してLLMにリクエストを送信
-        response = await ollama.AsyncClient().chat(
-            model='deepseek-r1:1.5b',  # 使用するモデルを指定 (例: 'llama3', 'gemma')
-            messages=[{'role': 'user', 'content': prompt}]
-        )
-        return response['message']['content'].strip()
-    except Exception as e:
-        logging.error(f"Ollamaでの分析中にエラーが発生しました: {e}")
+    novelty_analyzer = novelty_analyzer or NoveltyAnalyzer()
 
-        return "Ollamaでの分析中にエラーが発生しました。Ollamaアプリが起動しているか、指定したモデル (`llama3`など) がダウンロードされているか確認してください。"
-
-
-async def fetch_arxiv_papers(search_query: str, max_results_per_query: int = 10):
-    """
-    複数のキーワードで論文を検索し、新規性を分析して結果を返す非同期関数
-
-    Args:
-        search_query (str): 検索したいキーワードのリスト
-        max_results_per_query (int): 1クエリあたりの最大取得論文数
-
-    Returns:
-        list: 論文情報の辞書を含むリスト。エラー時は空リストを返す。
-    """
-    unique_papers = {}
-
-    query = search_query 
-    logging.info(f"'{query}'に関する論文を検索中...")
+    logging.info("'%s' に関する論文を検索中...", search_query)
     params = {
-        'search_query': query,
-        'sortBy': 'submittedDate',
-        'sortOrder': 'descending',
-        'max_results': str(max_results_per_query)
+        "search_query": search_query,
+        "sortBy": "submittedDate",
+        "sortOrder": "descending",
+        "max_results": str(max_results_per_query),
     }
-    try:
-        response = requests.get(ARXIV_API_URL, params=params)
-        response.raise_for_status()
-        
-        root = ET.fromstring(response.content)
-        namespaces = {'arxiv': 'http://www.w3.org/2005/Atom'}
 
-        for entry in root.findall('arxiv:entry', namespaces):
-            paper_id = entry.find('arxiv:id', namespaces).text
-            if paper_id not in unique_papers: # 重複をチェック
-                title = entry.find('arxiv:title', namespaces).text.strip()
-                summary = entry.find('arxiv:summary', namespaces).text.strip().replace('\n', ' ')
-                
-                unique_papers[paper_id] = {
-                    'title': title,
-                    'authors': [author.find('arxiv:name', namespaces).text for author in entry.findall('arxiv:author', namespaces)],
-                    'summary': summary,
-                    'published_date': datetime.strptime(entry.find('arxiv:published', namespaces).text, "%Y-%m-%dT%H:%M:%SZ").strftime('%Y-%m-%d'),
-                    'url': paper_id,
-                    'novelty': '' # 後で分析結果を入れるための空欄
-                }
-    except requests.exceptions.RequestException as e:
-        logging.error(f"APIリクエストエラー (クエリ: {query}): {e}")
-    except ET.ParseError as e:
-        logging.error(f"XML解析エラー (クエリ: {query}): {e}")
+    try:
+        response = requests.get(ARXIV_API_URL, params=params, timeout=15)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        logging.error("APIリクエストエラー (クエリ: %s): %s", search_query, exc)
+        return []
+
+    try:
+        root = ET.fromstring(response.content)
+    except ET.ParseError as exc:
+        logging.error("XML解析エラー (クエリ: %s): %s", search_query, exc)
+        return []
+
+    unique_papers: Dict[str, Dict[str, Any]] = {}
+
+    for entry in root.findall("atom:entry", NAMESPACES):
+        paper_id = _extract_text(entry, "atom:id")
+        if not paper_id or paper_id in unique_papers:
+            continue
+
+        summary = _extract_text(entry, "atom:summary").replace("\n", " ")
+        published_raw = _extract_text(entry, "atom:published")
+        published_date = _normalise_published_date(published_raw)
+
+        authors = [
+            _extract_text(author, "atom:name")
+            for author in entry.findall("atom:author", NAMESPACES)
+            if _extract_text(author, "atom:name")
+        ]
+
+        unique_papers[paper_id] = {
+            "title": _extract_text(entry, "atom:title"),
+            "authors": authors,
+            "summary": summary,
+            "published_date": published_date,
+            "url": paper_id,
+            "novelty": "",
+        }
 
     if not unique_papers:
         return []
 
-    # LLMによる新規性分析を並行して実行
-    logging.info(f"{len(unique_papers)}件のユニークな論文の新規性を分析します...")
-    tasks = [
-        analyze_novelty_with_llm(paper['summary']) 
-        for paper in unique_papers.values()
-    ]
-    novelty_results = await asyncio.gather(*tasks)
+    logging.info("%d 件のユニークな文献の新規性を分析します...", len(unique_papers))
+    novelty_tasks = [novelty_analyzer.analyse(paper["summary"]) for paper in unique_papers.values()]
+    novelty_results = await asyncio.gather(*novelty_tasks, return_exceptions=True)
 
-    # 分析結果を元の辞書に格納
-    for paper, novelty_text in zip(unique_papers.values(), novelty_results):
-        paper['novelty'] = novelty_text
+    for paper, novelty_result in zip(unique_papers.values(), novelty_results):
+        if isinstance(novelty_result, Exception):  # pragma: no cover - defensive guard
+            logging.error("新規性分析のタスクが失敗しました: %s", novelty_result)
+            paper["novelty"] = "新規性分析中に予期しないエラーが発生しました。ログを確認してください。"
+        else:
+            paper["novelty"] = novelty_result
 
-    # 投稿日でソートしてリストとして返す
-    sorted_papers = sorted(list(unique_papers.values()), key=lambda p: p['published_date'], reverse=True)
+    sorted_papers = sorted(unique_papers.values(), key=lambda p: p["published_date"], reverse=True)
     return sorted_papers
 
-if __name__ == '__main__':
-    test_query = "happy"
-    results = asyncio.run(fetch_arxiv_papers(search_query=test_query, max_results_per_query=3))
-    
-    if results:
-        for i, paper in enumerate(results):
+
+def _extract_text(element: ET.Element, path: str) -> str:
+    text = element.findtext(path, default="", namespaces=NAMESPACES)
+    return text.strip() if text else ""
+
+
+def _normalise_published_date(published_raw: str) -> str:
+    if not published_raw:
+        return ""
+
+    try:
+        return datetime.strptime(published_raw, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%d")
+    except ValueError:
+        return published_raw.split("T")[0]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke test helper
+    test_query = "all:\"happy\""
+
+    async def _run_test():
+        return await fetch_arxiv_papers(search_query=test_query, max_results_per_query=3)
+
+    test_results = asyncio.run(_run_test())
+
+    if test_results:
+        for i, paper in enumerate(test_results, start=1):
             print("-" * 50)
-            print(f"論文 {i+1}")
+            print(f"論文 {i}")
             print(f"タイトル: {paper['title']}")
             print(f"URL: {paper['url']}")
             print(f"novelty: {paper['novelty']}")

--- a/app/main.py
+++ b/app/main.py
@@ -1,56 +1,71 @@
-import streamlit as st
 import asyncio
-from arxiv_fetcher import fetch_arxiv_papers # こちらのファイルに変更はありません
 
-# --- ページ設定 ---
+import streamlit as st
+
+from arxiv_fetcher import NoveltyAnalyzer, fetch_arxiv_papers
+
+
 st.set_page_config(
-    page_title="arXiv Trend Analyzer with Local LLM",
+    page_title="arXiv Trend Analyzer with Local GPU LLM",
     page_icon="🔬",
-    layout="wide"
+    layout="wide",
 )
 
-# --- メイン画面 ---
-st.title("🔬 ローカルLLM搭載 arXivトレンド分析アプリ")
-st.markdown("""
-このアプリは、arXiv.orgに投稿された論文を検索し、**あなたのPCで動作するLLMが各論文の新規性を要約**します。
+st.title("🔬 GPUローカル要約付き arXivトレンド分析アプリ")
+st.markdown(
+    """
+このアプリは、arXiv.orgに投稿された論文を検索し、**ローカルGPUで動作する要約モデルが各論文の新規性を要約**します。
 複数のキーワードを**カンマ（,）**で区切って入力することで、それら全てを含む論文をAND検索できます。
-""")
-st.warning("**注意:** このアプリを使用するには、事前にOllamaをインストールし、バックグラウンドで起動しておく必要があります。")
+"""
+)
+st.warning(
+    "**注意:** 初回の推論時に要約モデルをダウンロードします。GPUが利用可能な場合は自動的に使用しますが、CPUでも動作します。"
+)
 
-
-# --- サイドバー ---
 st.sidebar.header("検索設定")
-# AND検索用のキーワード入力欄 (text_inputを使用)
 search_keywords_input = st.sidebar.text_input(
     "検索キーワード (カンマ区切りでAND検索)",
-    'computer vision, object detection, transformer',
+    "computer vision, object detection, transformer",
     help="""
     複数のキーワードをカンマ（,）で区切って入力してください。\n
     例: `deep learning, medical imaging, segmentation`
-    """
+    """,
 )
-# 取得件数
 max_results = st.sidebar.slider("最大取得件数", 5, 100, 20)
 
-# --- 検索実行と結果表示 ---
+novelty_analyzer = NoveltyAnalyzer()
+
+
+def _run_fetch(query: str, limit: int):
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(
+            fetch_arxiv_papers(query, limit, novelty_analyzer=novelty_analyzer)
+        )
+    finally:
+        loop.run_until_complete(asyncio.sleep(0))
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
 if st.sidebar.button("分析を実行"):
-    
-    keywords = [k.strip() for k in search_keywords_input.split(',') if k.strip()]
+    keywords = [k.strip() for k in search_keywords_input.split(",") if k.strip()]
 
     if not keywords:
         st.warning("検索キーワードを入力してください。")
     else:
-        # キーワードリストから `all:"keyword1" AND all:"keyword2"` 形式のクエリを生成
         final_query = " AND ".join([f'all:"{k}"' for k in keywords])
         st.sidebar.success("生成されたクエリ:")
-        st.sidebar.code(final_query, language='text')
+        st.sidebar.code(final_query, language="text")
 
-        with st.spinner("論文データを取得し、ローカルLLMで新規性を分析しています... PCの性能によっては時間がかかります。"):
+        with st.spinner(
+            "論文データを取得し、GPU要約モデルで新規性を分析しています... PCの性能によっては時間がかかります。"
+        ):
             try:
-                # 生成した単一のクエリをリストに入れてfetcherに渡す
-                papers = asyncio.run(fetch_arxiv_papers([final_query], max_results))
-            except Exception as e:
-                st.error(f"処理中にエラーが発生しました: {e}")
+                papers = _run_fetch(final_query, max_results)
+            except Exception as exc:  # pragma: no cover - runtime guard for UI usage
+                st.error(f"処理中にエラーが発生しました: {exc}")
                 papers = []
 
         if papers:
@@ -58,16 +73,16 @@ if st.sidebar.button("分析を実行"):
 
             for i, paper in enumerate(papers):
                 st.markdown("---")
-                st.subheader(f"{i+1}. {paper['title']}")
+                st.subheader(f"{i + 1}. {paper['title']}")
                 st.write(f"**著者:** {', '.join(paper['authors'])}")
                 st.write(f"**投稿日:** {paper['published_date']}")
                 st.write(f"**arXivリンク:** [{paper['url']}]({paper['url']})")
 
-                st.markdown("##### 🤖 LLMによる新規性の要約")
-                st.info(paper['novelty'])
+                st.markdown("##### 🤖 要約モデルによる新規性の要約")
+                st.info(paper["novelty"])
 
                 with st.expander("元の要旨（Abstract）を読む"):
-                    st.write(paper['summary'])
+                    st.write(paper["summary"])
         else:
             st.error("論文が見つかりませんでした。キーワードやネットワーク接続を確認してください。")
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests>=2.32.0
+streamlit>=1.31.0
+transformers>=4.36.0
+torch>=2.1.0
+pytest>=7.4

--- a/tests/test_arxiv_fetcher.py
+++ b/tests/test_arxiv_fetcher.py
@@ -1,0 +1,89 @@
+import asyncio
+import sys
+import textwrap
+import types
+
+import pytest
+
+requests_stub = types.ModuleType("requests")
+requests_stub.exceptions = types.SimpleNamespace(RequestException=Exception)
+requests_stub.get = None
+sys.modules.setdefault("requests", requests_stub)
+
+from app import arxiv_fetcher
+
+
+class DummyResponse:
+    def __init__(self, payload: str):
+        self.content = payload.encode("utf-8")
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class DummyAnalyzer:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def analyse(self, abstract: str) -> str:
+        self.calls.append(abstract)
+        return f"ANALYSED::{len(self.calls)}"
+
+
+def test_fetch_arxiv_papers_parses_feed(monkeypatch):
+    xml_payload = textwrap.dedent(
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <entry>
+            <id>http://arxiv.org/abs/1234.5678v1</id>
+            <title>First Sample Paper</title>
+            <summary>First abstract.\nWith a newline.</summary>
+            <published>2024-05-01T12:00:00Z</published>
+            <author><name>Alice</name></author>
+            <author><name>Bob</name></author>
+          </entry>
+          <entry>
+            <id>http://arxiv.org/abs/2345.6789v1</id>
+            <title>Second Sample Paper</title>
+            <summary>Second abstract body.</summary>
+            <published>2024-06-01T08:30:00Z</published>
+            <author><name>Carol</name></author>
+          </entry>
+        </feed>
+        """
+    ).strip()
+
+    def fake_get(url, params, timeout):
+        assert url == arxiv_fetcher.ARXIV_API_URL
+        assert params["search_query"] == 'all:"test"'
+        assert params["max_results"] == "5"
+        return DummyResponse(xml_payload)
+
+    monkeypatch.setattr(arxiv_fetcher.requests, "get", fake_get)
+
+    analyzer = DummyAnalyzer()
+    papers = asyncio.run(
+        arxiv_fetcher.fetch_arxiv_papers(
+            'all:"test"',
+            5,
+            novelty_analyzer=analyzer,
+        )
+    )
+
+    assert [paper["title"] for paper in papers] == [
+        "Second Sample Paper",
+        "First Sample Paper",
+    ]
+    assert papers[0]["published_date"] == "2024-06-01"
+    assert papers[0]["summary"] == "Second abstract body."
+    assert analyzer.calls == [
+        "First abstract. With a newline.",
+        "Second abstract body.",
+    ]
+    assert papers[0]["novelty"] == "ANALYSED::2"
+
+
+def test_fetch_arxiv_papers_validates_query():
+    with pytest.raises(ValueError):
+        asyncio.run(arxiv_fetcher.fetch_arxiv_papers("", 3))


### PR DESCRIPTION
## Summary
- replace the Ollama-dependent novelty analysis with a GPU-enabled Hugging Face summarizer and improve arXiv parsing resilience
- adjust the Streamlit UI to build valid query strings and reuse a single analyzer instance safely
- add regression tests for the fetcher logic and declare the required dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36f205bc4832180181eef1f322f2a